### PR TITLE
Enhance game visuals

### DIFF
--- a/tornado-io/public/game.js
+++ b/tornado-io/public/game.js
@@ -46,10 +46,15 @@ function draw() {
     debris.forEach(d => {
       const x = d.x - camera.x + canvas.width / 2;
       const y = d.y - camera.y + canvas.height / 2;
+      ctx.save();
       ctx.fillStyle = '#888';
       ctx.beginPath();
       ctx.arc(x, y, 3, 0, Math.PI * 2);
       ctx.fill();
+      ctx.lineWidth = 1;
+      ctx.strokeStyle = '#555';
+      ctx.stroke();
+      ctx.restore();
     });
 
     Object.values(players).forEach(p => {

--- a/tornado-io/public/player.js
+++ b/tornado-io/public/player.js
@@ -17,10 +17,29 @@ class TornadoPlayer {
   render(ctx, camera, canvas) {
     const x = this.x - camera.x + canvas.width / 2;
     const y = this.y - camera.y + canvas.height / 2;
-    ctx.fillStyle = this.color;
+
+    ctx.save();
+    const gradient = ctx.createRadialGradient(
+      x - this.radius / 3,
+      y - this.radius / 3,
+      this.radius / 10,
+      x,
+      y,
+      this.radius
+    );
+    gradient.addColorStop(0, '#fff');
+    gradient.addColorStop(1, this.color);
+    ctx.fillStyle = gradient;
+    ctx.shadowColor = 'rgba(0, 0, 0, 0.3)';
+    ctx.shadowBlur = 8;
     ctx.beginPath();
     ctx.arc(x, y, this.radius, 0, Math.PI * 2);
     ctx.fill();
+    ctx.lineWidth = 2;
+    ctx.strokeStyle = 'rgba(0, 0, 0, 0.4)';
+    ctx.stroke();
+    ctx.restore();
+
     ctx.fillStyle = '#000';
     ctx.font = '16px sans-serif';
     ctx.textAlign = 'center';

--- a/tornado-io/public/style.css
+++ b/tornado-io/public/style.css
@@ -4,7 +4,7 @@ html, body {
   overflow: hidden;
   height: 100%;
   touch-action: none;
-  background: #f0f8ff;
+  background: linear-gradient(#f0f8ff, #d0e7ff);
 }
 
 canvas {


### PR DESCRIPTION
## Summary
- Add radial gradient shading, shadow, and outline to player rendering for more depth.
- Apply a soft blue gradient background to the page.
- Give debris pieces a subtle border to stand out.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a40ab15ad8832ebbd4241d4d37d337